### PR TITLE
Use os.path.join() to append path components

### DIFF
--- a/whatmp3
+++ b/whatmp3
@@ -236,7 +236,7 @@ def main():
 
 			if options.output and options.passkey and options.tracker and not options.notorrent:
 				if options.verbose: print('Creating torrent...')
-				torrent_command = 'mktorrent -p -a %s/announce -o "%s.torrent" "%s"' % (options.tracker + options.passkey, escape_backtick(options.torrent_dir + os.path.basename(mp3_dir)), mp3_dir)
+				torrent_command = 'mktorrent -p -a %s/announce -o "%s.torrent" "%s"' % (options.tracker + options.passkey, escape_backtick(os.path.join(options.torrent_dir, os.path.basename(mp3_dir))), mp3_dir)
 				if options.verbose: print(escape_backtick(torrent_command))
 				os.system(escape_backtick(torrent_command))
 


### PR DESCRIPTION
This PR fixes an issue I was encountering where running whatmp3 without an output path would create torrent files in the parent directory with the proper name prepended by the current directory's name (e.g. in the folder `rips`, a torrent would be called `../ripsMy Torrent Name.torrent`).

Signed-off-by: Tim Ekl lithium3141@gmail.com
