### PR TITLE
Remove FLAC bit depth in output folder name

### DIFF
--- a/whatmp3.py
+++ b/whatmp3.py
@@ -330,7 +330,8 @@ def main():
 
         for codec in codecs:
             outdir = os.path.basename(flacdir)
-            flacre = re.compile('FLAC', re.IGNORECASE)
+            flacre_str = '(16|24)((-| )*(bit|44|48|96)* *)*FLAC(16|24| )*((16|24)*(-| )*(bit|44|48|96)*)*'
+            flacre = re.compile(flacre_str, re.IGNORECASE)
             if flacre.search(outdir):
                 outdir = flacre.sub(codec, outdir)
             else:


### PR DESCRIPTION
I've noticed a lot of folders seem to have bit depth information in them (e.g. "16-48 FLAC"), so often this script will produce folders with names like "... [16-48 320]" which doesn't seem right. I changed the regex to catch as many cases as I could find, although this may break if the year or catalog number ends with 16/24 and is only separated by the string "FLAC" with a space.

Let me know if this is helpful. Maybe make it an CLI option?