### PR TITLE
Add Auto-dithering

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ a list of formats to transcode to. For each top level directory passed,
 a new directory containing the transcoded audio files and optionally
 a torrent (with `mktorrent`) are created.
 
-whatmp3 requires `flac`, `metaflac`, at least one kind of encoder (eg
-`lame`, `oggenc`).
+whatmp3 requires the `flac` and `python3-mutagen` packages and at least
+one kind of encoder (eg `lame`, `oggenc`).
 
 `mktorrent` and replaygain tools (eg `vorbisgain`) are optionally
 required.

--- a/whatmp3.py
+++ b/whatmp3.py
@@ -186,8 +186,9 @@ def setup_parser():
     p = argparse.ArgumentParser(
         description="whatmp3 transcodes audio files and creates torrents for them",
         argument_default=False,
-        epilog="""depends on flac, metaflac, mktorrent, and optionally oggenc, lame, neroAacEnc,
-        neroAacTag, mp3gain, aacgain, vorbisgain, and sox""")
+        epilog="""depends on flac, python3-mutagen, and optionally mktorrent,
+        oggenc, lame, neroAacEnc, neroAacTag, mp3gain, aacgain, vorbisgain,
+        and sox""")
     p.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
     for a in [
         [['-v', '--verbose'],     False,   'increase verbosity'],

--- a/whatmp3.py
+++ b/whatmp3.py
@@ -9,6 +9,8 @@ import sys
 import threading
 from fnmatch import fnmatch
 
+import mutagen.flac
+
 VERSION = "3.8"
 
 # DEFAULT CONFIGURATION
@@ -233,13 +235,11 @@ def system(cmd):
 
 def transcode(f, flacdir, mp3_dir, codec, opts, lock):
     tags = {}
+    metadata = mutagen.flac.FLAC(f)
     for tag in copy_tags:
-        tagcmd = "metaflac --show-tag='" + escape_quote(tag) + \
-                 "' '" + escape_quote(f) + "'"
-        t = re.sub('\S.+?=', '', os.popen(tagcmd).read().rstrip(), count=1)
+        t = metadata.get(tag, [None])[0]
         if t:
             tags.update({tag: escape_quote(t)})
-        del t
     if (opts.zeropad and 'TRACKNUMBER' in tags
        and len(tags['TRACKNUMBER']) == 1):
         tags['TRACKNUMBER'] = '0' + tags['TRACKNUMBER']

--- a/whatmp3.py
+++ b/whatmp3.py
@@ -25,9 +25,6 @@ torrent_dir = output
 # Do you want to zeropad tracknumbers? (1 => 01, 2 => 02 ...)
 zeropad = 1
 
-# Do you want to dither FLACs to 16/44 before encoding?
-dither = 0
-
 # Specify tracker announce URL
 tracker = None
 
@@ -205,7 +202,6 @@ def setup_parser():
         [['-C', '--nocue'],       False,   'do not copy cue files after conversion'],
         [['-H', '--nodots'],      False,   'do not copy dot/hidden files after conversion'],
         [['-w', '--overwrite'],   False,   'overwrite files in output dir'],
-        [['-d', '--dither'],      dither,  'dither FLACs to 16/44 before encoding'],
         [['-M', '--nocopyother'], False,   'do not copy additional files'],
         [['-z', '--zeropad'],     zeropad, 'zeropad tracknumbers (def: true)'],
     ]:
@@ -260,7 +256,7 @@ def transcode(f, flacdir, mp3_dir, codec, opts, lock):
     for tag in tags:
         tagline = tagline + " " + encoders[enc_opts[codec]['enc']][tag]
     tagline = tagline % tags
-    if opts.dither:
+    if metadata.info.bits_per_sample > 16:
         flac_cmd = dither_cmd + ' | ' + flac_cmd
     flac_cmd = "flac -sdc -- '" + escape_percent(escape_quote(f)) + \
                "' | " + flac_cmd


### PR DESCRIPTION
The script should automatically resample the flac if it has a bit-depth higher than 16. This is what's done in the standard crawler tool for certain RecommdED sites, and I don't want to check each dir to see if it's 24-bit. I also added the mutagen dependancy because it becomes very cumbersome to get the information I need otherwise. Finally, I adjusted the help info to remove mention of `metaflac` which is now optional only for replay-gain with flac, because the `metaflac` binary should already be included with the `flac` package anyways.

The mutagen module is only used to _read_ the audio tags and not to write them, as it's better to use the encoders for that. I tested this commit by transcoding my entire music collection on my phone to MP3 V0. All of the tags are accounted for and it still sounds great.