### PR TITLE
Added an option to follow symlinks

### DIFF
--- a/whatmp3.1
+++ b/whatmp3.1
@@ -4,6 +4,7 @@ whatmp3 \- transcode audio files and create torrents
 .SH SYNOPSIS
 .B whatmp3
 .RB [ \-v ]
+.RB [ \-f ]
 .RB [ \-h ]
 .RB [ \-\-version ]
 .RB [ \-n ]
@@ -74,6 +75,9 @@ prints version information to standard output, then exits.
 .TP
 .BR \-v \fR,\ \fB\-\-verbose
 prints extra information to screen
+.TP
+.BR \-f \fR,\ \fB\-\-followlinks
+visit directories pointed to by symlinks, on systems that support them
 .TP
 .BR \-n \fR,\ \fB\-\-notorrent
 does not create a torrent even if a tracker announce url is provided

--- a/whatmp3.py
+++ b/whatmp3.py
@@ -114,7 +114,6 @@ dither_cmd = 'sox -t wav - -b 16 -t wav - rate 44100 dither'
 
 codecs = []
 
-
 def copy_other(opts, flacdir, outdir):
     if opts.verbose:
         print('COPYING other files')

--- a/whatmp3.py
+++ b/whatmp3.py
@@ -114,10 +114,11 @@ dither_cmd = 'sox -t wav - -b 16 -t wav - rate 44100 dither'
 
 codecs = []
 
+
 def copy_other(opts, flacdir, outdir):
     if opts.verbose:
         print('COPYING other files')
-    for dirpath, dirs, files in os.walk(flacdir, topdown=False):
+    for dirpath, dirs, files in os.walk(flacdir, topdown=False, followlinks=opts.followlinks):
         for name in files:
             if opts.nolog and fnmatch(name.lower(), '*.log'):
                 continue
@@ -177,7 +178,7 @@ def replaygain(opts, codec, outdir):
         print(encoders[enc_opts[codec]['enc']]['regain'] % outdir)
     r = system(encoders[enc_opts[codec]['enc']]['regain'] % escape_quote(outdir))
     if r: failure(r, "replaygain")
-    for dirpath, dirs, files in os.walk(outdir, topdown=False):
+    for dirpath, dirs, files in os.walk(outdir, topdown=False, followlinks=opts.followlinks):
         for name in dirs:
             r = system(encoders[enc_opts[codec]['enc']]['regain']
                        % os.path.join(dirpath, name))
@@ -192,6 +193,7 @@ def setup_parser():
     p.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
     for a in [
         [['-v', '--verbose'],     False,   'increase verbosity'],
+        [['-f', '--followlinks'], False, 'visit directories pointed to by symlinks, on systems that support them'],
         [['-n', '--notorrent'],   False,   'do not create a torrent after conversion'],
         [['-r', '--replaygain'],  False,   'add ReplayGain to new files'],
         [['-c', '--original'],    False,   'create a torrent for the original FLAC'],
@@ -311,7 +313,7 @@ def main():
         flacfiles = []
         if not os.path.exists(opts.torrent_dir):
             os.makedirs(opts.torrent_dir)
-        for dirpath, dirs, files in os.walk(flacdir, topdown=False):
+        for dirpath, dirs, files in os.walk(flacdir, topdown=False, followlinks=opts.followlinks):
             for name in files:
                 if fnmatch(name.lower(), '*.flac'):
                     flacfiles.append(os.path.join(dirpath, name))


### PR DESCRIPTION
By default, the `os.walk` function from Python does not follow symlinks, and so running whatmp3 against directories containing symlinks is unsuccessful.

This simple PR includes a new option for whatmp3, `-f`, which causes it to pass `followlinks=True` to the `os.walk` function, allowing whatmp3 to follow symlinks in operating systems which support them.